### PR TITLE
quick fix to change domains on links related to twitter inside markdown files from `twitter.com` to `x.com`

### DIFF
--- a/blog/members/draft-member.md
+++ b/blog/members/draft-member.md
@@ -38,7 +38,7 @@ class: "member-gravatar"
 [.](https://instagram.com/joe.doe)
 ```
 ```{rst-class} i-icon social-media x-twitter
-[.](https://twitter.com/joe.doe)
+[.](https://x.com/joe.doe)
 ```
 ```{rst-class} i-icon social-media youtube
 [.](https://youtube.com/@joe.doe)

--- a/blog/members/hellhound.md
+++ b/blog/members/hellhound.md
@@ -34,7 +34,7 @@ class: "member-gravatar"
 [.](https://www.instagram.com/hellhoundorf)
 ```
 ```{rst-class} i-icon social-media x-twitter
-[.](https://twitter.com/hellhoundorf)
+[.](https://x.com/hellhoundorf)
 ```
 
 :Aliases: hellhound

--- a/blog/members/mario21ic.md
+++ b/blog/members/mario21ic.md
@@ -25,7 +25,7 @@ class: "member-gravatar"
 [.](https://linkedin.com/in/mario21ic)
 ```
 ```{rst-class} i-icon social-media x-twitter
-[.](https://twitter.com/mario21ic)
+[.](https://x.com/mario21ic)
 ```
 
 :Aliases: mario21ic

--- a/blog/members/richi.md
+++ b/blog/members/richi.md
@@ -25,7 +25,7 @@ class: "member-gravatar"
 [.](https://linkedin.com/in/richard-cancino-061413151/)
 ```
 ```{rst-class} i-icon social-media x-twitter
-[.](https://twitter.com/rc_moons)
+[.](https://x.com/rc_moons)
 ```
 
 :Aliases: richi

--- a/blog/members/soloidx.md
+++ b/blog/members/soloidx.md
@@ -25,7 +25,7 @@ class: "member-gravatar"
 [.](https://linkedin.com/in/soloidx)
 ```
 ```{rst-class} i-icon social-media x-twitter
-[.](https://twitter.com/soloidx)
+[.](https://x.com/soloidx)
 ```
 
 :Aliases: soloidx

--- a/blog/members/zodiacfireworks.md
+++ b/blog/members/zodiacfireworks.md
@@ -34,7 +34,7 @@ class: "member-gravatar"
 [.](https://www.instagram.com/zodiacfireworks)
 ```
 ```{rst-class} i-icon social-media x-twitter
-[.](https://twitter.com/zodiacfireworks)
+[.](https://x.com/zodiacfireworks)
 ```
 
 :Aliases: zodiacfireworks


### PR DESCRIPTION
to run this again later for whole repo and only do changes on markdown files

```sh
$ find . -type f -name "*.md" -exec sed -i 's|//twitter.com|//x.com|g' {} +
```

once your terminal's working directory is inside this `python.pe` git repo

ps: it assumes you have `find` and `sed`

edit: used `//twitter.com` on `sed` expression to avoid writing whole `https://twitter.com`, but if there is any link in markdown format like this

```md
[ref](twitter.com/...)
```

this definitely won't work 😞, probably an alternative could be

```sh
$ find . -type f -name "*.md" -exec sed -i 's|twitter.com|x.com|g' {} +
```

always search for `twitter` findings on `python.pe` repo

-> [`https://github.com/search?q=repo:pythonpe/python.pe twitter&type=code`](https://github.com/search?q=repo%3Apythonpe%2Fpython.pe%20twitter&type=code)