### PR TITLE
Incluir dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "16:00"
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-patch']
+    labels: ['dependencies']
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "16:00"
+    labels: ["dependencies"]


### PR DESCRIPTION
👋🏼 Hola, sería bueno incluir en el repositorio el siguiente archivo para que se notifique vulnerabilidades y cuando se requiera evaluar actualizar las nuevas versiones de las dependencias y de las acciones de GitHub.
[![IMAGE ALT TEXT HERE](https://img.youtube.com/vi/Mh8yZu01DI8/0.jpg)](https://www.youtube.com/watch?v=Mh8yZu01DI8)