### PR TITLE
Adding talk brainstorming section

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -215,6 +215,7 @@ extensions = [
     "embed",
     "gravatar",
     "sketchviz",
+    "notion",
 ]
 
 myst_enable_extensions = [

--- a/events.md
+++ b/events.md
@@ -9,3 +9,10 @@ list-style: circle
 excerpts:
 ---
 ```
+
+```{toctree}
+:caption: Secciones
+:hidden: true
+
+talk-brainstorming.md
+```

--- a/ext/gravatar.py
+++ b/ext/gravatar.py
@@ -38,7 +38,7 @@ class GravatarImage(Directive):
 
         data = {}
         if klass is not None:
-            data['classes'] = klass
+            data["classes"] = klass
 
         image = nodes.image(alt=alt, classes=klass, uri=url)
         return [image]

--- a/ext/notion.py
+++ b/ext/notion.py
@@ -28,7 +28,10 @@ class Notion(Directive):
             raise self.error("URL does not appear to be a valid Notion URL")
 
         para = nodes.raw(
-            "", TEMPLATE.format(url=url), format="html"
+         para = nodes.raw(
+-            "", TEMPLATE.format(url=url), format="html"
++            "", TEMPLATE.format(url=urllib.parse.quote(url, safe=":/?&=+")), format="html"
+         )
         )
         return [para]
 

--- a/ext/notion.py
+++ b/ext/notion.py
@@ -1,0 +1,33 @@
+"""A directive to generate an iframe with a Notion page."""
+
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from sphinx.application import Sphinx
+from sphinx.util import logging
+
+logger = logging.getLogger(__name__)
+
+TEMPLATE: str = """
+<iframe src="{url}" width="100%" height="1200" frameborder="0" allowfullscreen />
+"""
+
+
+class Notion(Directive):
+    has_content = True
+    final_argument_whitespace = False
+
+    def run(self):
+        para = nodes.raw(
+            "", TEMPLATE.format(url=self.content[0]), format="html"
+        )
+        return [para]
+
+
+def setup(app: Sphinx):
+    app.add_directive("notion",Notion)
+
+    return {
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/ext/notion.py
+++ b/ext/notion.py
@@ -1,5 +1,7 @@
 """A directive to generate an iframe with a Notion page."""
 
+import urllib.parse
+
 from docutils import nodes
 from docutils.parsers.rst import Directive
 from sphinx.application import Sphinx
@@ -24,20 +26,24 @@ class Notion(Directive):
             raise self.error("Notion directive only accepts a single URL")
         url = self.content[0]
         # Basic validation that it's a Notion URL
-        if not url.startswith(("https://notion.site", "https://www.notion.so")) and "notion" not in url:
+        if (
+            not url.startswith(
+                ("https://notion.site", "https://www.notion.so")
+            )
+            and "notion" not in url
+        ):
             raise self.error("URL does not appear to be a valid Notion URL")
 
         para = nodes.raw(
-         para = nodes.raw(
--            "", TEMPLATE.format(url=url), format="html"
-+            "", TEMPLATE.format(url=urllib.parse.quote(url, safe=":/?&=+")), format="html"
-         )
+            "",
+            TEMPLATE.format(url=urllib.parse.quote(url, safe=":/?&=+")),
+            format="html",
         )
         return [para]
 
 
 def setup(app: Sphinx):
-    app.add_directive("notion",Notion)
+    app.add_directive("notion", Notion)
 
     return {
         "version": "0.1",

--- a/ext/notion.py
+++ b/ext/notion.py
@@ -18,8 +18,17 @@ class Notion(Directive):
     final_argument_whitespace = False
 
     def run(self):
+        if not self.content:
+            raise self.error("Notion directive requires a URL")
+        if len(self.content) > 1:
+            raise self.error("Notion directive only accepts a single URL")
+        url = self.content[0]
+        # Basic validation that it's a Notion URL
+        if not url.startswith(("https://notion.site", "https://www.notion.so")) and "notion" not in url:
+            raise self.error("URL does not appear to be a valid Notion URL")
+
         para = nodes.raw(
-            "", TEMPLATE.format(url=self.content[0]), format="html"
+            "", TEMPLATE.format(url=url), format="html"
         )
         return [para]
 

--- a/ext/notion.py
+++ b/ext/notion.py
@@ -8,7 +8,8 @@ from sphinx.util import logging
 logger = logging.getLogger(__name__)
 
 TEMPLATE: str = """
-<iframe src="{url}" width="100%" height="1200" frameborder="0" allowfullscreen />
+<iframe src="{url}" width="100%" height="1200" frameborder="0" allowfullscreen>
+</iframe>
 """
 
 

--- a/index.md
+++ b/index.md
@@ -79,7 +79,7 @@ Revisa nuestras normas de como integrarte en la comunidad de Python Perú.
 ```
 
 ```{toctree}
-:caption: Secciónes
+:caption: Secciones
 :hidden: true
 
 about.md

--- a/talk-brainstorming.md
+++ b/talk-brainstorming.md
@@ -1,0 +1,4 @@
+# Brainstorming de Charlas
+
+```{notion} https://forested-roadrunner-0a7.notion.site/ebd/1e114afe2a67809c9ff0eb9429b1d3c7?v=1e114afe2a6780d88e41000c2debb2b5
+```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a directive to embed Notion pages directly within documentation.
  - Added a new "Brainstorming de Charlas" section that displays a Notion page.

- **Documentation**
  - Included a hidden section in the events documentation for additional content.
  - Corrected a typographical error in a section caption for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->