### PR TITLE
Changed hellhound.md

### DIFF
--- a/blog/members/hellhound.md
+++ b/blog/members/hellhound.md
@@ -1,13 +1,14 @@
 ---
 blogpost: true
-date: 19 Apr, 2024
-author: hellhound
-location: Lima, Perú
+author: Jean-Pierre Chauvel
+location: Lima
 category: members
 language: Español
 image: 1
 excerpt: 1
 ---
+
+% NOTA: No olvidar poner la fecha de publicación debajo de `blogpost: true`
 
 # Jean-Pierre Chauvel
 
@@ -64,7 +65,6 @@ class: "member-gravatar"
 
 :Homepage: https://chauvel.org
 
-
 ## Sobre mí
 
 ### ¿Quién eres y a qué te dedicas?
@@ -97,4 +97,4 @@ de mi carrera, solo algunos scriptcillos que están en mi cuenta de GitHub.
 
 ### ¿Estás disponible para hacer mentoring, consultorías, charlas?
 
-¡Claro!
+¡Claro!1


### PR DESCRIPTION
Changing an entry to `blog/members` for Jean-Pierre Chauvel (alias: hellhound).